### PR TITLE
Change default behaviour for include_in_theme_distributions to True

### DIFF
--- a/src/lib/configuration_objects.py
+++ b/src/lib/configuration_objects.py
@@ -5,7 +5,7 @@ class CodingModes(object):
 
 class CodingConfiguration(object):
     def __init__(self, coding_mode, code_scheme, coded_field, fold_strategy, analysis_file_key=None, cleaner=None,
-                 include_in_theme_distribution=False, include_in_individuals_file=True):
+                 include_in_theme_distribution=True, include_in_individuals_file=True):
         assert coding_mode in {CodingModes.SINGLE, CodingModes.MULTIPLE}
 
         self.coding_mode = coding_mode


### PR DESCRIPTION
I think this is the more sensible default, and brings this pipeline in line with G&A pipelines. It also provides a nice fix for the empty theme_distributions file