### PR TITLE
use age categories in theme distribution files

### DIFF
--- a/configurations/coding_plans.py
+++ b/configurations/coding_plans.py
@@ -176,7 +176,6 @@ KAKUMA_DEMOG_CODING_PLANS = [
                        coded_field="location_coded",
                        analysis_file_key="location",
                        fold_strategy=FoldStrategies.assert_label_ids_equal,
-                       include_in_theme_distribution=Codes.TRUE
                    ),
                ],
                ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET.get_code_with_match_value("kakuma location"),
@@ -194,7 +193,6 @@ KAKUMA_DEMOG_CODING_PLANS = [
                        coded_field="gender_coded",
                        analysis_file_key="gender",
                        fold_strategy=FoldStrategies.assert_label_ids_equal,
-                       include_in_theme_distribution=Codes.TRUE
                    )
                ],
                ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET.get_code_with_match_value("kakuma gender"),
@@ -212,7 +210,7 @@ KAKUMA_DEMOG_CODING_PLANS = [
                        coded_field="age_coded",
                        analysis_file_key="age",
                        fold_strategy=FoldStrategies.assert_label_ids_equal,
-                       include_in_theme_distribution=Codes.FALSE
+                       include_in_theme_distribution=False
                    ),
                    CodingConfiguration(
                        coding_mode=CodingModes.SINGLE,
@@ -220,7 +218,6 @@ KAKUMA_DEMOG_CODING_PLANS = [
                        coded_field="age_category_coded",
                        analysis_file_key="age_category",
                        fold_strategy=FoldStrategies.assert_label_ids_equal,
-                       include_in_theme_distribution=Codes.TRUE
                    )
                ],
                code_imputation_function=code_imputation_functions.impute_age_category,
@@ -238,7 +235,6 @@ KAKUMA_DEMOG_CODING_PLANS = [
                        coded_field="household_language_coded",
                        analysis_file_key="household_language",
                        fold_strategy=FoldStrategies.assert_label_ids_equal,
-                       include_in_theme_distribution=Codes.TRUE
                    )
                ],
                ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET.get_code_with_match_value("kakuma household language"),
@@ -255,7 +251,6 @@ KAKUMA_DEMOG_CODING_PLANS = [
                        coded_field="nationality_coded",
                        analysis_file_key="nationality",
                        fold_strategy=FoldStrategies.assert_label_ids_equal,
-                       include_in_theme_distribution=Codes.TRUE
                    )
                ],
                ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET.get_code_with_match_value("kakuma nationality"),
@@ -272,7 +267,6 @@ KAKUMA_DEMOG_CODING_PLANS = [
                        coded_field="kalobeyei_participants_engaging_coded",
                        analysis_file_key="kalobeyei_participants_engaging",
                        fold_strategy=FoldStrategies.assert_label_ids_equal,
-                       include_in_theme_distribution=Codes.TRUE
                    )
                ],
                ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET.get_code_with_match_value("leap kalobeyei participants engaging"),
@@ -289,7 +283,6 @@ KAKUMA_DEMOG_CODING_PLANS = [
                        coded_field="kalobeyei_targeted_group_parent_coded",
                        analysis_file_key="kalobeyei_targeted_group_parent",
                        fold_strategy=FoldStrategies.assert_label_ids_equal,
-                       include_in_theme_distribution=Codes.TRUE
                    )
                ],
                ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET.get_code_with_match_value("leap kalobeyei targeted group parent"),
@@ -306,7 +299,6 @@ KAKUMA_DEMOG_CODING_PLANS = [
                        coded_field="kalobeyei_child_gender_coded",
                        analysis_file_key="kalobeyei_child_gender",
                        fold_strategy=FoldStrategies.assert_label_ids_equal,
-                       include_in_theme_distribution=Codes.TRUE
                    )
                ],
                ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET.get_code_with_match_value("leap kalobeyei child gender"),
@@ -323,7 +315,6 @@ KAKUMA_DEMOG_CODING_PLANS = [
                        coded_field="kalobeyei_consent_to_engage_child_coded",
                        analysis_file_key="kalobeyei_consent_to_engage_child",
                        fold_strategy=FoldStrategies.assert_label_ids_equal,
-                       include_in_theme_distribution=Codes.TRUE
                    )
                ],
                ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET.get_code_with_match_value("leap kalobeyei consent to engage child"),
@@ -337,12 +328,21 @@ KAKUMA_DEMOG_CODING_PLANS = [
                    CodingConfiguration(
                        coding_mode=CodingModes.SINGLE,
                        code_scheme=CodeSchemes.KALOBEYEI_AGE_OF_PARENT,
+                       cleaner=lambda text: clean_age_with_range_filter(text),
                        coded_field="kalobeyei_age_of_parent_coded",
                        analysis_file_key="kalobeyei_age_of_parent",
                        fold_strategy=FoldStrategies.assert_label_ids_equal,
-                       include_in_theme_distribution=Codes.TRUE
+                       include_in_theme_distribution=False
+                   ),
+                   CodingConfiguration(
+                       coding_mode=CodingModes.SINGLE,
+                       code_scheme=CodeSchemes.AGE_CATEGORY,
+                       coded_field="kalobeyei_age_of_parent_category_coded",
+                       analysis_file_key="kalobeyei_age_of_parent_category",
+                       fold_strategy=FoldStrategies.assert_label_ids_equal,
                    )
                ],
+               code_imputation_function=code_imputation_functions.impute_age_category,
                ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET.get_code_with_match_value("leap kalobeyei age of parent"),
                raw_field_fold_strategy=FoldStrategies.assert_equal),
 
@@ -357,7 +357,6 @@ KAKUMA_DEMOG_CODING_PLANS = [
                        coded_field="kalobeyei_currently_in_school_coded",
                        analysis_file_key="kalobeyei_currently_in_school",
                        fold_strategy=FoldStrategies.assert_label_ids_equal,
-                       include_in_theme_distribution=Codes.TRUE
                    )
                ],
                ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET.get_code_with_match_value("leap kalobeyei currently in school"),


### PR DESCRIPTION
This;
- Resolves a bug where the theme distribution script was using Codes.TRUE/FALSE to check whether to include a coding plan to theme distribution file or not instead of using python booleans. 
- Imputes age_category variable for both age and age of the parent datasets instead of individual age entries.